### PR TITLE
Last internal --> public change (crosses fingers)

### DIFF
--- a/SwiftLibs/WebRequest.swift
+++ b/SwiftLibs/WebRequest.swift
@@ -10,7 +10,7 @@ public class WebRequest : NSObject {
         var _headers : Dictionary<String, String> = Dictionary<String, String>()
         var _data : String!
 
-        internal init(wasSuccess : Bool) {
+        public init(wasSuccess : Bool) {
             _wasSuccess = wasSuccess
         }
 


### PR DESCRIPTION
Updated WebRequest.Response to have a public constructor for use when used with embedded framework.

Could you also regen the framework release, I am not sure what the process is behind that.

Thanks buddy!
