### PR TITLE
Feature/set http body in web request

### DIFF
--- a/SwiftLibs/Test/MockWebRequest.swift
+++ b/SwiftLibs/Test/MockWebRequest.swift
@@ -70,6 +70,10 @@ public class MockWebRequest : WebRequest {
         self.mocker.recordInvocation("addMultiPart", paramList: [multiPart])
     }
 
+    public override func setBody(body: String) {
+        self.mocker.recordInvocation("setBody", paramList: [body])
+    }
+
     public class _executeResponse {
         public var request : WebRequest!
         public var response : Response!

--- a/SwiftLibs/WebRequest.swift
+++ b/SwiftLibs/WebRequest.swift
@@ -234,13 +234,6 @@ public class WebRequest : NSObject {
 
     public func setFollowRedirects(followRedirects : Bool) { _sessionDelegate.setFollowRedirects(followRedirects) }
 
-    public func setBody(body: String) {
-        _multiparts.removeAll()
-        _postParams.removeAll()
-
-        _rawBody = body.dataUsingEncoding(NSUTF8StringEncoding)!
-    }
-
     public func setGetParam(key key : String, value : String) { _getParams[key] = value }
 
     public func setPostParam(key key : String, value : String) {
@@ -278,6 +271,13 @@ public class WebRequest : NSObject {
         }
     }
 
+    public func setBody(body: String) {
+        _multiparts.removeAll()
+        _postParams.removeAll()
+
+        _rawBody = body.dataUsingEncoding(NSUTF8StringEncoding)!
+    }
+    
     internal func _generatePostBody() -> String {
         var postBody : String = ""
         for key : String in _postParams.keys {

--- a/SwiftLibs/WebRequest.swift
+++ b/SwiftLibs/WebRequest.swift
@@ -208,7 +208,7 @@ public class WebRequest : NSObject {
     internal var _cookies : Dictionary<String, String> = Dictionary<String, String>()
     internal var _sessionDelegate : _SessionDelegate = _SessionDelegate.newInstance()
     internal var _multiparts : Array<MultiPart> = Array<MultiPart>()
-
+    internal var _rawBody: NSData!
 
     internal static func _doesDataContainData(needle needle: NSData, haystack: NSData) -> Bool {
         return (haystack.rangeOfData(needle, options: NSDataSearchOptions.Backwards, range: NSMakeRange(0, haystack.length)).location != NSNotFound)
@@ -234,10 +234,18 @@ public class WebRequest : NSObject {
 
     public func setFollowRedirects(followRedirects : Bool) { _sessionDelegate.setFollowRedirects(followRedirects) }
 
+    public func setBody(body: String) {
+        _multiparts.removeAll()
+        _postParams.removeAll()
+
+        _rawBody = body.dataUsingEncoding(NSUTF8StringEncoding)!
+    }
+
     public func setGetParam(key key : String, value : String) { _getParams[key] = value }
 
     public func setPostParam(key key : String, value : String) {
         _multiparts.removeAll()
+        _rawBody = nil
 
         _postParams[key] = value
     }
@@ -260,6 +268,7 @@ public class WebRequest : NSObject {
 
     public func addMultiPart(multiPart : MultiPart) {
         _postParams.removeAll()
+        _rawBody = nil
 
         if (multiPart.isValid()) {
             _multiparts.append(multiPart)
@@ -420,11 +429,12 @@ public class WebRequest : NSObject {
             }
         }
 
-        // Post Body
-        if (postBody != nil) {
+        // Create Body
+        if (_rawBody != nil) {
+            request.HTTPBody = _rawBody!
+        } else if (postBody != nil) {
             request.HTTPBody = postBody!.dataUsingEncoding(NSUTF8StringEncoding)
-        }
-        else if (multiPartBody != nil) {
+        } else if (multiPartBody != nil) {
             request.HTTPBody = multiPartBody!
         }
 

--- a/SwiftLibsTests/WebRequestTests.swift
+++ b/SwiftLibsTests/WebRequestTests.swift
@@ -90,6 +90,17 @@ class WebRequestTests: XCTestCase {
         XCTAssertEqual(_subject._multiparts.count, 0, "Setting a post param must clear out multiparts.")
     }
 
+    func testSetPostParamClearsRawBody() {
+        // Setup
+        _subject._rawBody = "This is data I do not wish to see anymore!".dataUsingEncoding(NSUTF8StringEncoding)
+
+        // Action
+        _subject.setPostParam(key: "key", value: "value")
+
+        // Assert
+        XCTAssertNil(_subject._rawBody, "Setting a post param must clear out the raw body.")
+    }
+
     func testAddMultipartClearsPostParams() {
         // Setup
         _subject._postParams["key"] = "value"
@@ -99,6 +110,39 @@ class WebRequestTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(_subject._postParams.count, 0, "Adding a multipart object must clear out post params.")
+    }
+
+    func testAddMultipartClearsRawBody() {
+        // Setup
+        _subject._rawBody = "This is data I do not wish to see anymore!".dataUsingEncoding(NSUTF8StringEncoding)
+
+        // Action
+        _subject.addMultiPart(WebRequest.MultiPart(contentDisposition: .INLINE, name: "multipart"))
+
+        // Assert
+        XCTAssertNil(_subject._rawBody, "Adding a multipart objec must clear out the raw body.")
+    }
+
+    func testSetBodyClearsMultiParts() {
+        // Setup
+        _subject._multiparts.append(WebRequest.MultiPart(contentDisposition: .INLINE, name: "multipart"))
+
+        // Action
+        _subject.setBody("This is a value that I am setting")
+
+        // Assert
+        XCTAssertEqual(_subject._multiparts.count, 0, "Setting the body directly must clear out multiparts.")
+    }
+
+    func testSetBodyClearsPostParams() {
+        // Setup
+        _subject._postParams["key"] = "value"
+
+        // Action
+        _subject.setBody("This is a value that I am setting")
+
+        // Assert
+        XCTAssertEqual(_subject._postParams.count, 0, "Setting the body directly must clear out post params.")
     }
 
     func testAddInvalidMultipartDoesNotAppendMultiPart() {
@@ -415,4 +459,18 @@ class WebRequestTests: XCTestCase {
         // Assert
         XCTAssertEqual(header, expectedHeader)
     }
+
+    func testSetBodyStoresTheDataToBeSent() {
+        // Setup
+        let expectedBodyText : String = "This is very important data - whatever you do, don't lose..."
+        let expectedBodyData : NSData = expectedBodyText.dataUsingEncoding(NSUTF8StringEncoding)!
+        _subject.setBody(expectedBodyText)
+
+        // Action
+        let actualBody = _subject._rawBody
+
+        // Assert
+        XCTAssertEqual(actualBody, expectedBodyData)
+    }
+
 }

--- a/SwiftLibsTests/WebRequestTests.swift
+++ b/SwiftLibsTests/WebRequestTests.swift
@@ -120,7 +120,7 @@ class WebRequestTests: XCTestCase {
         _subject.addMultiPart(WebRequest.MultiPart(contentDisposition: .INLINE, name: "multipart"))
 
         // Assert
-        XCTAssertNil(_subject._rawBody, "Adding a multipart objec must clear out the raw body.")
+        XCTAssertNil(_subject._rawBody, "Adding a multipart object must clear out the raw body.")
     }
 
     func testSetBodyClearsMultiParts() {


### PR DESCRIPTION
This PR adds the ability to set the body directly on a WebRequest without using POST params or MultiPart.  Added public method to MockWebRequest as well.
