### PR TITLE
Bug/spaces in url crash web request

### DIFF
--- a/SwiftLibs/WebRequest.swift
+++ b/SwiftLibs/WebRequest.swift
@@ -226,7 +226,11 @@ public class WebRequest : NSObject {
         }
     }
 
-    public func setUrl(url : String) { _url = url }
+    public func setUrl(url : String) {
+        let allowedCharacters = NSMutableCharacterSet.URLHostAllowedCharacterSet().mutableCopy()
+        allowedCharacters.formUnionWithCharacterSet(NSCharacterSet.URLPathAllowedCharacterSet())
+        _url = url.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacters as! NSCharacterSet)
+    }
 
     public func setMethod(method : HttpMethod) { _method = method }
 

--- a/SwiftLibsTests/WebRequestTests.swift
+++ b/SwiftLibsTests/WebRequestTests.swift
@@ -415,4 +415,26 @@ class WebRequestTests: XCTestCase {
         // Assert
         XCTAssertEqual(header, expectedHeader)
     }
+
+    func testSetUrlDoesNotEscapeCharactersRequiredInRootOfUrl() {
+        // Setup
+        let expectedUrl = "https://www.potter.com:1234/index.badphp"
+
+        // Action
+        _subject.setUrl(expectedUrl)
+
+        // Assert
+        XCTAssertEqual(_subject._url, expectedUrl)
+    }
+
+    func testSetUrlEscapesSpacesInRootOfUrl() {
+        // Setup
+        let expectedUrl = "spaced%20out"
+
+        // Action
+        _subject.setUrl("spaced out")
+
+        // Assert
+        XCTAssertEqual(_subject._url, expectedUrl)
+    }
 }


### PR DESCRIPTION
Resubmit of earlier PR to allow escaping of spaces in base url so that WebRequest does not crash.
